### PR TITLE
prevencion de inutilizacion del contrato

### DIFF
--- a/AgreementService.sol
+++ b/AgreementService.sol
@@ -35,6 +35,7 @@ contract AgreementService {
         valorEnWei = _valorEnEther * 1 ether;
         multaEnWei = valorEnWei / 10;
         emit AcuerdoCreado(parteUno, parteDos, _valorEnEther);
+        require(parteUno != parteDos); // este requisito es para prevenir poner dos veces la misma direccion volviendo el contrato inutilizable.
     }
 
     modifier soloParteUno() {


### PR DESCRIPTION
el requisito require(parteUno != parteDos); es importante para prevenir que alguien se equivoque y ponga dos veces la misma direccion en la creacion del contrato.